### PR TITLE
Update configmap-files.yaml

### DIFF
--- a/templates/configmap-files.yaml
+++ b/templates/configmap-files.yaml
@@ -3,4 +3,6 @@ kind: ConfigMap
 metadata:
   name: {{ include "helm-bitwarden-unified.fullname" . }}-files
 data:
-  {{ (.Files.Glob "files/nginx-config.hbs").AsConfig }}
+  nginx-config.hbs: |
+    {{- range .Files.Lines "files/nginx-config.hbs" }}
+    {{ . }}{{ end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
               subPath: nginx-config.hbs
           envFrom:
             - configMapRef:
-                name: bitwarden-environment
+                name: {{ include "helm-bitwarden-unified.fullname" . }}-environment
           livenessProbe:
             httpGet:
               path: /


### PR DESCRIPTION
- Resolving indentation issue in helm chart file configmap-files.yaml "Unable to convert YAML as JSON on line 9" "Unexpected :"
- Resolved an issue in deployment.yaml where "environment configmap" was statically declared but dinamically deployed, so the name didn't match